### PR TITLE
fix: remove token verify method

### DIFF
--- a/app/common/routes/index.js
+++ b/app/common/routes/index.js
@@ -21,56 +21,32 @@ import StreetUpdatePage from 'containers/pages/StreetUpdatePage';
 import SignInPage from 'containers/pages/SignInPage';
 import NotFoundPage from 'containers/pages/NotFoundPage';
 
-import { verifyToken, getToken } from 'redux/session';
-import { isAuthorized } from 'reducers';
-
-import { PUBLIC_INDEX_ROUTE } from 'config';
-
-export const configureRoutes = ({ store }) => { // eslint-disable-line
-  const requireAuth = async (nextState, replace, next) => {
-    if (__CLIENT__) {
-      if (!isAuthorized(store.getState())) {
-        replace({ pathname: PUBLIC_INDEX_ROUTE });
-      }
-    } else {
-      // FIXME: We should handle case when there is no token passed
-      const token = await store.dispatch(getToken());
-      const { error } = await store.dispatch(verifyToken(token));
-      if (error) {
-        replace({ pathname: PUBLIC_INDEX_ROUTE });
-      }
-    }
-
-    return next();
-  };
-
-  return (
-    <Route component={App}>
-      <Route component={Main} onEnter={requireAuth}>
-        <Route path="/" component={PreloadData}>
-          <IndexRedirect to="regions" />
-          <Route path="regions">
-            <IndexRoute component={RegionsPage} />
-            <Route path=":id" component={RegionUpdatePage} />
-          </Route>
-          <Route path="districts">
-            <IndexRoute component={DistrictsPage} />
-            <Route path=":id" component={DistrictUpdatePage} />
-          </Route>
-          <Route path="settlements">
-            <IndexRoute component={SettlementsPage} />
-            <Route path=":id" component={SettlementUpdatePage} />
-          </Route>
-          <Route path="streets">
-            <IndexRoute component={StreetsPage} />
-            <Route path=":id" component={StreetUpdatePage} />
-          </Route>
+export const configureRoutes = () => (
+  <Route component={App}>
+    <Route component={Main}>
+      <Route path="/" component={PreloadData}>
+        <IndexRedirect to="regions" />
+        <Route path="regions">
+          <IndexRoute component={RegionsPage} />
+          <Route path=":id" component={RegionUpdatePage} />
+        </Route>
+        <Route path="districts">
+          <IndexRoute component={DistrictsPage} />
+          <Route path=":id" component={DistrictUpdatePage} />
+        </Route>
+        <Route path="settlements">
+          <IndexRoute component={SettlementsPage} />
+          <Route path=":id" component={SettlementUpdatePage} />
+        </Route>
+        <Route path="streets">
+          <IndexRoute component={StreetsPage} />
+          <Route path=":id" component={StreetUpdatePage} />
         </Route>
       </Route>
-      <Route path="sign-in" component={SignInPage} />
-      <Route component={Main}>
-        <Route path="*" component={NotFoundPage} />
-      </Route>
     </Route>
-  );
-};
+    <Route path="sign-in" component={SignInPage} />
+    <Route component={Main}>
+      <Route path="*" component={NotFoundPage} />
+    </Route>
+  </Route>
+);

--- a/app/common/store/index.js
+++ b/app/common/store/index.js
@@ -1,15 +1,23 @@
 
 import { createStore, applyMiddleware, compose } from 'redux';
-import { routerMiddleware } from 'react-router-redux';
+import { routerMiddleware, push } from 'react-router-redux';
 import promiseMiddleware from 'redux-promise';
 import thunkMiddleware from 'redux-thunk';
 import multiMiddleware from 'redux-multi';
 import { apiMiddleware } from 'redux-api-middleware';
+import { PUBLIC_INDEX_ROUTE } from 'config';
 
 import rootReducer from '../reducers';
 
+const errorHandlerMiddleware = store => next => (action) => {
+  if (action.error && action.payload.status === 401) {
+    store.dispatch(push(PUBLIC_INDEX_ROUTE));
+  }
+  return next(action);
+};
+
 const middlewares = [
-  multiMiddleware, promiseMiddleware, apiMiddleware,
+  multiMiddleware, promiseMiddleware, apiMiddleware, errorHandlerMiddleware,
 ];
 
 if (process.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Description
Remove token verify method from router

## Related Issue
https://github.com/edenlabllc/ehealth.web/issues/2015

## Motivation and Context
Removed token verify method because it not work with jwt token. And this method is unnecessary. All back-end methods call token verify include or public (without token validation).